### PR TITLE
Update Actions to publish a release on tag events

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -9,6 +9,8 @@ name: .NET Framework Desktop
 on:
   push:
     branches: [ "main" ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches: [ "main" ]
 
@@ -42,7 +44,13 @@ jobs:
         run: msbuild ExamplePostApp.sln -t:rebuild -property:Configuration=Release
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with: 
           name: ExamplePostAppExecutable
           path: D:\a\ExamplePostApp\ExamplePostApp\bin\Release\ExamplePostApp.exe
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: D:\a\ExamplePostApp\ExamplePostApp\bin\Release\ExamplePostApp.exe
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
This PR will upload the compiled binary to a published GitHub release on all tag actions. Once merged into main, pull main and apply a tag such as `git tag -s v0.1.0` to mark a version, then `git push --tags` to kick off the tag workflow.